### PR TITLE
fixed private headers being exposed when included via cocoapods

### DIFF
--- a/sundown.podspec
+++ b/sundown.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
 
   s.source       =  { :git => 'https://github.com/Daij-Djan/sundown.git', :tag => '0.1.0' }
   s.source_files = 'src/*.{h,c,m}', 'html/*.{h,c}'
+  s.public_header_files = 'src/SundownWrapper.h'
   s.requires_arc = true
 end
 


### PR DESCRIPTION
which could result in duplicate symbol linker errors due to the methods defined in html_blocks.h

relates to https://github.com/b-ray/cocoapods-static-frameworks/issues/2